### PR TITLE
Add responsive <Nav /> component

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
   },
   "dependencies": {
     "@tippy.js/react": "^2.2.0",
+    "react-feather": "^2.0.3",
     "rebass": "^3.x.x",
     "styled-normalize": "^8.x.x",
     "styled-system": "^4.x.x"

--- a/src/Nav/Nav.stories.tsx
+++ b/src/Nav/Nav.stories.tsx
@@ -4,35 +4,31 @@ import { storiesOf, addDecorator } from "@storybook/react";
 import { Nav } from "./Nav";
 import { PrimaryButton } from "../Button";
 
-addDecorator(storyFn => (
+const ChangefeedNav = () => (
   <div style={{ height: "200vh" }}>
-    {storyFn()}
+    <Nav>
+      <Box pr={3}>
+        <strong>Some</strong>product
+      </Box>
+      <Nav.Content>
+        <Flex flexDirection={["column", "row", "row"]}>
+          <Nav.Item href="#">About</Nav.Item>
+          <Nav.Item href="#">Our Story</Nav.Item>
+          <Nav.Item href="#">Pricing</Nav.Item>
+        </Flex>
+        <Flex
+          pt={[2, 0]}
+          pb={[3, 0]}
+          justifyContent={["center", ""]}
+          width={[1, "auto"]}
+        >
+          <PrimaryButton>Get started</PrimaryButton>
+        </Flex>
+      </Nav.Content>
+    </Nav>
 
     <h1>Navbar</h1>
   </div>
-));
-
-const ChangefeedNav = () => (
-  <Nav>
-    <Box pr={3}>
-      <strong>Some</strong>product
-    </Box>
-    <Nav.Content>
-      <Flex flexDirection={["column", "row", "row"]}>
-        <Nav.Item href="#">About</Nav.Item>
-        <Nav.Item href="#">Our Story</Nav.Item>
-        <Nav.Item href="#">Pricing</Nav.Item>
-      </Flex>
-      <Flex
-        pt={[2, 0]}
-        pb={[3, 0]}
-        justifyContent={["center", ""]}
-        width={[1, "auto"]}
-      >
-        <PrimaryButton>Get started</PrimaryButton>
-      </Flex>
-    </Nav.Content>
-  </Nav>
 );
 
 storiesOf("Nav", module)

--- a/src/Nav/Nav.stories.tsx
+++ b/src/Nav/Nav.stories.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Flex, Box } from "rebass";
+import { storiesOf, addDecorator } from "@storybook/react";
+import { Nav } from "./Nav";
+import { PrimaryButton } from "../Button";
+
+addDecorator(storyFn => (
+  <div style={{ height: "200vh" }}>
+    {storyFn()}
+
+    <h1>Navbar</h1>
+  </div>
+));
+
+const ChangefeedNav = () => (
+  <Nav>
+    <Box pr={3}>
+      <strong>Some</strong>product
+    </Box>
+    <Nav.Content>
+      <Flex flexDirection={["column", "row", "row"]}>
+        <Nav.Item href="#">About</Nav.Item>
+        <Nav.Item href="#">Our Story</Nav.Item>
+        <Nav.Item href="#">Pricing</Nav.Item>
+      </Flex>
+      <Flex
+        pt={[2, 0]}
+        pb={[3, 0]}
+        justifyContent={["center", ""]}
+        width={[1, "auto"]}
+      >
+        <PrimaryButton>Get started</PrimaryButton>
+      </Flex>
+    </Nav.Content>
+  </Nav>
+);
+
+storiesOf("Nav", module)
+  .add("Desktop", ChangefeedNav)
+  .add("Mobile", ChangefeedNav, { viewport: { defaultViewport: "iphonex" } });

--- a/src/Nav/Nav.stories.tsx
+++ b/src/Nav/Nav.stories.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Flex, Box } from "rebass";
-import { storiesOf, addDecorator } from "@storybook/react";
+import { storiesOf } from "@storybook/react";
 import { Nav } from "./Nav";
 import { PrimaryButton } from "../Button";
 

--- a/src/Nav/Nav.tsx
+++ b/src/Nav/Nav.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { Wrapper } from "./components/Wrapper";
+import { Navbar } from "./components/Navbar";
+import { Item } from "./components/Item";
+import { Content } from "./components/Content";
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const Nav = (props: Props) => {
+  return (
+    <Wrapper mb={3}>
+      <Navbar {...props}>{props.children}</Navbar>
+    </Wrapper>
+  );
+};
+
+Nav.Item = Item;
+Nav.Content = Content;
+
+export { Nav };

--- a/src/Nav/components/Content.tsx
+++ b/src/Nav/components/Content.tsx
@@ -5,14 +5,14 @@ import { defaultBreakpoints } from "styled-system";
 import { ChevronDown } from "react-feather";
 import { theme } from "../../theme";
 
-const Mobile = styled(Flex)`
+const Mobile = styled(Flex)<FlexProps>`
   display: none;
   @media screen and (max-width: ${defaultBreakpoints[0]}) {
     display: flex;
   }
 `;
 
-const Desktop = styled(Flex)`
+const Desktop = styled(Flex)<FlexProps>`
   @media screen and (max-width: ${defaultBreakpoints[0]}) {
     display: none;
   }
@@ -52,11 +52,12 @@ export const Content = (props: FlexProps) => {
         justifyContent="space-between"
         width={1}
         {...props}
+        ref={undefined}
       />
       <Mobile
         flexDirection="row"
         justifyContent="flex-end"
-        alignitems="center"
+        alignItems="center"
         width={1}
       >
         <UnstyledButton onClick={() => setIsOpen(!isOpen)}>

--- a/src/Nav/components/Content.tsx
+++ b/src/Nav/components/Content.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import styled from "styled-components";
+import { Flex, FlexProps } from "rebass";
+import { defaultBreakpoints } from "styled-system";
+import { ChevronDown } from "react-feather";
+import { theme } from "../../theme";
+
+const Mobile = styled(Flex)`
+  display: none;
+  @media screen and (max-width: ${defaultBreakpoints[0]}) {
+    display: flex;
+  }
+`;
+
+const Desktop = styled(Flex)`
+  @media screen and (max-width: ${defaultBreakpoints[0]}) {
+    display: none;
+  }
+`;
+
+const MobileExpandedWrapper = styled(Flex)`
+  position: absolute;
+  top: 100%;
+  width: 100%;
+  height: 100vh;
+  left: 0;
+  background: rgba(0, 0, 0, 0.1);
+`;
+
+const MobileExpandedCard = styled(Flex)`
+  position: absolute;
+  background: white;
+  top: 0;
+`;
+
+const UnstyledButton = styled.button`
+  padding: 0;
+  margin: 0;
+  background: none;
+  border: none;
+  outline: none;
+`;
+
+export const Content = (props: FlexProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <>
+      <Desktop
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="space-between"
+        width={1}
+        {...props}
+      />
+      <Mobile
+        flexDirection="row"
+        justifyContent="flex-end"
+        alignitems="center"
+        width={1}
+      >
+        <UnstyledButton onClick={() => setIsOpen(!isOpen)}>
+          <ChevronDown
+            style={{
+              transform: `rotate(${isOpen ? `180deg` : `0deg`})`,
+              transition: `transform 100ms ease-in-out`
+            }}
+            color={theme.darks.six}
+          />
+        </UnstyledButton>
+        {isOpen && (
+          <MobileExpandedWrapper onClick={() => setIsOpen(false)}>
+            <MobileExpandedCard flexDirection="column" width={1}>
+              {props.children}
+            </MobileExpandedCard>
+          </MobileExpandedWrapper>
+        )}
+      </Mobile>
+    </>
+  );
+};

--- a/src/Nav/components/Item.tsx
+++ b/src/Nav/components/Item.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { Box, LinkProps, Flex } from "rebass";
 import { theme } from "../../theme";
-import { defaultBreakpoints } from "styled-system";
+import { defaultBreakpoints, FlexProps } from "styled-system";
 import { ChevronRight } from "react-feather";
 
 const Mobile = styled(Box)`
@@ -58,10 +58,12 @@ const Link = styled(Flex).attrs(props => ({
 
 export const Item = (props: LinkProps) => {
   return (
+    // @ts-ignore
     <Link
       justifyContent={["space-between", "initial"]}
       alignItems="center"
       {...props}
+      ref={undefined}
     >
       {props.children}
       <Mobile style={{ height: "1em" }}>

--- a/src/Nav/components/Item.tsx
+++ b/src/Nav/components/Item.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { Box, LinkProps, Flex } from "rebass";
 import { theme } from "../../theme";
-import { defaultBreakpoints, FlexProps } from "styled-system";
+import { defaultBreakpoints } from "styled-system";
 import { ChevronRight } from "react-feather";
 
 const Mobile = styled(Box)`

--- a/src/Nav/components/Item.tsx
+++ b/src/Nav/components/Item.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import styled from "styled-components";
+import { Box, LinkProps, Flex } from "rebass";
+import { theme } from "../../theme";
+import { defaultBreakpoints } from "styled-system";
+import { ChevronRight } from "react-feather";
+
+const Mobile = styled(Box)`
+  display: none;
+  @media screen and (max-width: ${defaultBreakpoints[0]}) {
+    display: flex;
+  }
+`;
+
+const Link = styled(Flex).attrs(props => ({
+  as: props.as || "a"
+}))`
+  color: ${theme.darks.zero};
+  text-decoration: none;
+  background-color: transparent;
+  transition: background 100ms ease-out;
+  padding: 8px 16px;
+  border-radius: 4px;
+  line-height: normal;
+  cursor: pointer;
+
+  :hover {
+    background-color: ${theme.lights.four};
+  }
+
+  :active,
+  :focus {
+    color: ${theme.darks.zero};
+  }
+
+  @media screen and (max-width: ${defaultBreakpoints[0]}) {
+    border-bottom: 1px solid ${theme.ui.border};
+    padding: 16px 0;
+    margin: 0px 16px;
+
+    svg {
+      transition: transform 100ms ease-in-out;
+    }
+
+    &:hover {
+      background-color: transparent;
+    }
+
+    &:hover svg {
+      transform: translateX(2px);
+    }
+
+    &:last-of-type {
+      border-bottom: none;
+    }
+  }
+`;
+
+export const Item = (props: LinkProps) => {
+  return (
+    <Link
+      justifyContent={["space-between", "initial"]}
+      alignItems="center"
+      {...props}
+    >
+      {props.children}
+      <Mobile style={{ height: "1em" }}>
+        <ChevronRight size="1.5em" color={theme.darks.six} />
+      </Mobile>
+    </Link>
+  );
+};

--- a/src/Nav/components/Navbar.tsx
+++ b/src/Nav/components/Navbar.tsx
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+import { Flex } from "rebass";
+import { theme } from "../../theme";
+
+export const Navbar = styled(Flex).attrs({
+  flexDirection: "row",
+  alignItems: "center",
+  p: 3
+})({
+  backgroundColor: "white",
+  boxShadow: theme.shadow.large,
+  position: "fixed",
+  top: 0,
+  left: 0,
+  right: 0,
+  zIndex: 99
+});

--- a/src/Nav/components/Wrapper.tsx
+++ b/src/Nav/components/Wrapper.tsx
@@ -1,0 +1,4 @@
+import styled from "styled-components";
+import { Flex } from "rebass";
+
+export const Wrapper = styled(Flex)({ position: "relative", height: "65px" });

--- a/src/Nav/index.tsx
+++ b/src/Nav/index.tsx
@@ -1,0 +1,1 @@
+export * from "./Nav";

--- a/yarn.lock
+++ b/yarn.lock
@@ -9014,6 +9014,13 @@ react-fast-compare@^2.0.2:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-feather@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-2.0.3.tgz#1453ff5d8c242f72b8c02846118fbd2d406375ad"
+  integrity sha512-XVjtxIyMxb2RFlqC2APoB/IZvXKDW9uLN1c264XEeZNYe8jIxjQVQpeTo3nxtHiLTgMfgf0ZYxJC6HwmY8+9BA==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-focus-lock@^1.17.7:
   version "1.19.1"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-1.19.1.tgz#2f3429793edaefe2d077121f973ce5a3c7a0651a"


### PR DESCRIPTION
# [View the live demo](https://nice-boys-components-git-nav.nice-boys.now.sh/?path=/story/nav--desktop)

Extracted from Changefeed with a much nicer API. The demo in Storybook rebuilds the Changefeed nav in ~15 lines of extra code :100:

```JSX
  <Nav>
    <Logo />
    {/* This is hidden on mobile and renders a hamburger instead */}
    <Nav.Content>
      <Flex flexDirection={["column", "row", "row"]}>
        <Nav.Item href="#">About</Nav.Item>
        <Nav.Item href="#">Our Story</Nav.Item>
        <Nav.Item href="#">Pricing</Nav.Item>
      </Flex>
      <Flex
        pt={[2, 0]}
        pb={[3, 0]}
        justifyContent={["center", ""]}
        width={[1, "auto"]}
      >
        <PrimaryButton>Get started</PrimaryButton>
      </Flex>
    </Nav.Content>
  </Nav>
```

Closes #93 